### PR TITLE
Script to parse downloaded tagtog zip archive

### DIFF
--- a/tagtog/parse_tagtog_archive.py
+++ b/tagtog/parse_tagtog_archive.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python
+"""
+Instructions:
+
+    * Download zip tagtog archive here: 
+
+	https://tagtog.net/ikhomyakov/bangladesh_floods/-downloads/dataset-as-anndoc
+
+    * Unzip it.
+
+    * And then parse it, for example, as follows:
+
+	./parse_tagtog_archive.py ~/Downloads/bangladesh_floods_20200828 >data_20200828.csv
+
+Currently hardcoded to retrieve annotations only from master, shammun, and btellman
+
+"""
+import os
+import sys
+from pathlib import Path
+import json
+
+import csv
+from typing import Tuple, Dict, List, Any, Optional
+import datetime
+import re
+from html.parser import HTMLParser
+
+if len(sys.argv) < 2:
+    print(f"Usage: {sys.argv[0]} tagtog_archive_dir >file.csv", file=sys.stderr)
+    sys.exit(1)
+
+root_path = Path(sys.argv[1])
+ann_path = Path(root_path, "ann.json")
+article_path = Path(root_path, "plain.html")
+master_ann_path = Path(ann_path, "master")
+members_ann_path = Path(ann_path, "members")
+shammun_ann_path = Path(members_ann_path, "shammun")
+btellman_ann_path = Path(members_ann_path, "btellman")
+ann_legend_path = Path(root_path, "annotations-legend.json")
+
+with open(ann_legend_path, "r") as f:
+    legend = json.load(f)
+
+regex_abra_cadabra = r"^[@#]*$"
+
+
+class ContentParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.is_content = 0
+        self.content = []
+
+    def handle_starttag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]):
+        if tag == "div":
+            self.is_content += 1
+
+    def handle_endtag(self, tag: str):
+        if tag == "div":
+            self.is_content -= 1
+
+    def handle_data(self, content: str):
+        if self.is_content != 0:
+            self.content += [
+                y
+                for y in (x.strip() for x in content.strip().split("\n"))
+                if re.match(regex_abra_cadabra, y) is None
+            ]
+
+
+drop_list = [
+    # "Date",
+    # "Division1",
+    # "Division2",
+    # "Division3",
+    # "District1",
+    # "District2",
+    # "District3",
+    # "District4",
+    # "District5",
+]
+
+
+def empty_entry(legend: Dict[str, str]) -> Dict[str, Any]:
+    rs: Dict[str, Any] = {}
+    for k in legend.keys():
+        if k[0] == "m":
+            rs[legend[k]] = None
+    rs["__anncomplete"] = False
+    return rs
+
+
+def drop_fields(d: Dict[str, Any], drop_list: List[str]) -> Dict[str, Any]:
+    return {k: v for k, v in d.items() if k not in drop_list}
+
+
+date_regex_articles = re.compile(r"^(\d\d\d\d-\d\d-\d\d).*$")
+date_regex_dhaka = re.compile(r"^Date Published:\s*(\d\d\d\d-\d\d-\d\d).*$")
+
+
+def parse_article(
+    article_id: str, folder: str, content: str
+) -> Tuple[str, Optional[datetime.date]]:
+    parser = ContentParser()
+    parser.feed(content)
+    dt = None
+
+    for i, s in enumerate(parser.content):
+        m = re.match(
+            date_regex_articles if folder == "/pool/articles" else date_regex_dhaka, s
+        )
+        if m is not None:
+            dt = datetime.datetime.strptime(m.group(1), "%Y-%m-%d").date()
+            parser.content.pop(i)
+            break
+
+    return (parser.content, dt)
+
+
+def traverse_annotations(output: Dict[str, Any], root_path: Path, path: Path) -> None:
+    for x in os.scandir(path):
+        if x.is_dir():
+            traverse_annotations(output, root_path, Path(x.path))
+        else:
+            folder = str(Path(x.path).parent)[len(str(root_path)) :]
+            article_id = Path(x.path).with_suffix("").stem
+            with open(x.path, "r") as f:
+                annotations = json.load(f)
+            anncomplete = annotations["anncomplete"]
+            metas = annotations["metas"]
+            if article_id not in output or (
+                anncomplete and not output[article_id]["__anncomplete"]
+            ):
+                output[article_id] = dict(
+                    __article_id=article_id,
+                    __folder=folder,
+                    __anncomplete=anncomplete,
+                    **{legend[k]: v["value"] for k, v in metas.items()}
+                )
+
+
+def traverse_articles(output: Dict[str, Any], root_path: Path, path: Path) -> None:
+    for x in os.scandir(path):
+        if x.is_dir():
+            traverse_articles(output, root_path, Path(x.path))
+        else:
+            folder = str(Path(x.path).parent)[len(str(root_path)) :]
+            article_id = Path(x.path).with_suffix("").stem
+            with open(x.path, "r") as f:
+                article = f.read()
+            content, dt = parse_article(article_id, folder, article)
+            lines = len(content)
+            length = len(content)
+            output[article_id] = dict(
+                __article_id=article_id,
+                __folder=folder,
+                __content="\n".join(content),
+                __date=dt,
+            )
+
+
+articles: Dict[str, Any] = {}
+traverse_articles(articles, article_path, article_path)
+
+annotations: Dict[str, Any] = {}
+traverse_annotations(annotations, master_ann_path, master_ann_path)
+traverse_annotations(annotations, shammun_ann_path, shammun_ann_path)
+traverse_annotations(annotations, btellman_ann_path, btellman_ann_path)
+
+
+if len(articles) != 0:
+    keys = list(
+        set(empty_entry(legend).keys())
+        | set(annotations[next(iter(annotations))].keys())
+        | set(articles[next(iter(articles))].keys())
+    )
+
+    keys = [
+        "__article_id",
+        "__date",
+        "__anncomplete",
+        "__folder",
+        "is_flood",
+        "is_Bangladesh",
+        "type",
+        "flood_related",
+        "flood-climatechange",
+        "newspaper",
+        "anomaly_issue",
+        "__content",
+        "Date",
+        "Division1",
+        "Division2",
+        "Division3",
+        "District1",
+        "District2",
+        "District3",
+        "District4",
+        "District5",
+    ]
+
+    w = csv.DictWriter(sys.stdout, keys, lineterminator="\n")
+    w.writeheader()
+    for k in sorted(articles.keys()):
+        r = empty_entry(legend)
+        if k in annotations:
+            r.update(annotations[k])
+        r.update(articles[k])
+        r = drop_fields(r, drop_list)
+        w.writerow(r)


### PR DESCRIPTION
A script that parses tagtog zip archive with articles and annotations and produces CSV file. This works much faster than downloading the articles via API and appears to be more reliable as well. Another benefit is that you have the full snapshot of articles with their annotations on your computer and can reproduce the experiments reliably. Please find the usage instructions below and in the script. 

Instructions:

* Download zip tagtog archive here: 

	https://tagtog.net/ikhomyakov/bangladesh_floods/-downloads/dataset-as-anndoc

* Unzip it.

* And then parse it, for example, as follows:

	./parse_tagtog_archive.py ~/Downloads/bangladesh_floods_20200828 >data_20200828.csv

